### PR TITLE
Scuffed Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+build/
+test_logs/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,42 @@
 # Crashlogs
-A simple way to output stack traces when a program crashes in C++, using the new C++23 &lt;stacktrace> header
-currently windows-only, but if anyone wants to add mac or linux support I'll merge it in
+A simple way to output stack traces when a program crashes in C++, using the new C++23 `<stacktrace>` header.  
+Works on Windows. Kind of works on Linux.
 
-usage: include the files in your project, then call  
-glaiel::crashlogs::begin_monitoring();  
-to enable crash handling (probably do this at the start of your program)
+## Usage
 
-when the program crashes, it will save a timestamped stack trace to the folder specified with  
-glaiel::crashlogs::set_crashlog_folder(folder_path);
+include the files in your project, then call  
+Call `glaiel::crashlogs::begin_monitoring` to enable crash handling (probablly do this at the start of your program).  
+Monitoring and writing the crashlog is done in a worker thread.
+
+when the program crashes, it will save a timestamped stack trace to the folder specified with `glaiel::crashlogs::set_crashlog_folder(folder_path);`
 
 some additional customizability and callbacks are documented in the header file
 
 
 note: the stack trace outputted will include a bunch of error handling stuff at the top. It would be nice to skip printing the first X stack trace entries, but how many to skip seems kinda dependent on optimization settings and which condition triggered the error handler, so I did not bother with that yet.
+
+<!-- TODO add example output (preferably from windows) -->
+
+### Linux (GCC) support
+
+*Note that at the time of writing GCC (13.1.1) and its implementation of the C++ standard library consider the backtrace feature to be experimental!*  
+This means that you need to manually link against `stdc++_libbacktrace`.
+
+Also the backtraces currently look like this
+```
+Received signal 11 SIGSEGV
+   0#      at :32588
+   1#      at :32588
+   2#      at :32588
+   3#      at :32588
+   4#      at :32588
+   5#      at :32588
+   6#      at :32588
+   7# 
+```
+like they're pretty useless, I'd stick to a different solution until GCC has finished the backtrace feature fully.
+
+### Testing
+
+`TestTool.cpp` is a very simple command line tool to test a few different cases.  
+It will enable the monitoring and delibrately crash so you can manually verify the handler works.

--- a/TestTool.cpp
+++ b/TestTool.cpp
@@ -17,11 +17,13 @@ enum class TestType
     Terminate,
     IllegalInstruction,
     UnhandledException,
+    StackOverflow,
 };
 
 // forward declarations so we can use these in main
-[[nodiscard]] std::optional<TestType> testTypeFromString(std::string_view str);
 void usage(const char *arg0);
+[[nodiscard]] std::optional<TestType> testTypeFromString(std::string_view str);
+void causeStackOverflow(int val);
 
 int main(int argc, char **argv)
 {
@@ -89,6 +91,12 @@ int main(int argc, char **argv)
         throw std::logic_error("Whoops");
     }
     break;
+    case TestType::StackOverflow:
+    {
+        std::cout << "Causing StackOverflow" << std::endl;
+        causeStackOverflow(0);
+    }
+    break;
     }
 
     return 0;
@@ -120,5 +128,13 @@ std::optional<TestType> testTypeFromString(std::string_view str)
         return TestType::IllegalInstruction;
     if (str == "UnhandledException" || str == "unhandledexception")
         return TestType::UnhandledException;
+    if (str == "StackOverflow" || str == "stackoverflow")
+        return TestType::StackOverflow;
     return std::nullopt;
+}
+
+void causeStackOverflow(int val)
+{
+    causeStackOverflow(val + 1);
+    std::cout << " " << val;
 }

--- a/TestTool.cpp
+++ b/TestTool.cpp
@@ -1,0 +1,124 @@
+// A very simple CLI tool to manually test the different cases of Crashlog.
+// It's not really possible to unit test crashing, so this will have to suffice.
+
+#include <iostream>
+#include <thread>
+#include <optional>
+#include <string_view>
+
+#include <csignal>
+
+#include "crashlogs.h"
+
+enum class TestType
+{
+    Segfault,
+    Abort,
+    Terminate,
+    IllegalInstruction,
+    UnhandledException,
+};
+
+// forward declarations so we can use these in main
+[[nodiscard]] std::optional<TestType> testTypeFromString(std::string_view str);
+void usage(const char *arg0);
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+    {
+        usage(argv[0]);
+        return 1;
+    }
+    const auto testTypeParsed = testTypeFromString(argv[1]);
+    if (!testTypeParsed.has_value())
+    {
+        std::cerr << "Cannot parse `" << argv[1] << "` as a valid test type!\n"
+                  << std::endl;
+        usage(argv[0]);
+        return 2;
+    }
+    const TestType testType = testTypeParsed.value();
+
+    std::cout << "Initializing crashlogs" << std::endl;
+
+    glaiel::crashlogs::set_crashlog_folder("./test_logs");
+    glaiel::crashlogs::begin_monitoring();
+
+    std::cout << "Gonna wait a second..." << std::endl;
+
+    for (int cnt = 0; cnt < 10; cnt++)
+    {
+        std::cout << ".";
+        std::cout.flush();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    std::cout << std::endl;
+
+    switch (testType)
+    {
+    case TestType::Segfault:
+    {
+        std::cout << "Causing Segfault" << std::endl;
+        int *a = nullptr;
+        int b = *a + 1;
+    }
+    break;
+    case TestType::Abort:
+    {
+        std::cout << "Causing Abort" << std::endl;
+        std::abort();
+    }
+    break;
+    case TestType::Terminate:
+    {
+        std::cout << "Causing Terminate" << std::endl;
+        std::terminate();
+    }
+    break;
+    case TestType::IllegalInstruction:
+    {
+        std::cout << "Causing IllegalInstruction" << std::endl;
+        // no idea how to cause this delibrately so I'm just raising the signal manually
+        std::raise(SIGILL);
+    }
+    break;
+    case TestType::UnhandledException:
+    {
+        std::cout << "Causing UnhandledException" << std::endl;
+        throw std::logic_error("Whoops");
+    }
+    break;
+    }
+
+    return 0;
+}
+
+void usage(const char *arg0)
+{
+    std::cerr << "Usage: \n";
+    std::cerr << "\t" << arg0 << " <TestType>\n";
+    std::cerr << "\n"
+                 "\tWith valid test types:\n"
+                 "\t - 'Segfault'\n"
+                 "\t - 'Abort'\n"
+                 "\t - 'Terminate'\n"
+                 "\t - 'IllegalInstruction'\n"
+                 "\t - 'UnhandledException'"
+              << std::endl;
+}
+
+std::optional<TestType> testTypeFromString(std::string_view str)
+{
+    if (str == "Segfault" || str == "segfault")
+        return TestType::Segfault;
+    if (str == "Abort" || str == "abort")
+        return TestType::Abort;
+    if (str == "Terminate" || str == "terminate")
+        return TestType::Terminate;
+    if (str == "IllegalInstruction" || str == "illegalinstruction")
+        return TestType::IllegalInstruction;
+    if (str == "UnhandledException" || str == "unhandledexception")
+        return TestType::UnhandledException;
+    return std::nullopt;
+}

--- a/tests/TestTool.cpp
+++ b/tests/TestTool.cpp
@@ -8,7 +8,7 @@
 
 #include <csignal>
 
-#include "crashlogs.h"
+#include "../crashlogs.h"
 
 enum class TestType
 {
@@ -112,7 +112,8 @@ void usage(const char *arg0)
                  "\t - 'Abort'\n"
                  "\t - 'Terminate'\n"
                  "\t - 'IllegalInstruction'\n"
-                 "\t - 'UnhandledException'"
+                 "\t - 'UnhandledException'\n"
+                 "\t - 'StackOverflow'"
               << std::endl;
 }
 


### PR DESCRIPTION
Hey I actually got some preliminary Linux/Unix support ready... _kind of_.

* Disable windows specific code using the preprocessor and rely on the C++ standard lib for unix systems. *There is currently no specifics for Unix/Linux or GCC.*
* Add some more cout messages during the crash handler
* Add a `header_reason` string that is written at the top of the crashlog and write general information about the crash into it (e.g. `Received signal 11 SIGSEGV`)
* Add `TestTool.cpp`, a CLI tool that delibrately crashes to manually test the handler
* Updated the readme accordingly

A slight problem with all of this: Currently GCC (13.1.1 in my case) considers the [backtrace feature to be experimental](https://gcc.gnu.org/pipermail/gcc-bugs/2022-May/787683.html) and I could not get it to output a stacktrace that worth anything, which makes this entire thing a bit useless. I added a note about that to the readme.

On another note: A  lot of the things we want to do in this library are considered undefined behavior.
POSIX has many restrictions on what we're legally allowed to do in a signal handler and I feel like the C++ standard is even stricter on this, see the [Signal handler](https://en.cppreference.com/w/cpp/utility/program/signal) section on cppreference.
I don't think we can really circumvent UB when opening a new file, so I'd suggest making sure users know what they're signing up for.